### PR TITLE
Enable Sentry crash reporting in shipped builds

### DIFF
--- a/AuthContext.js
+++ b/AuthContext.js
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { Platform } from 'react-native';
 import * as SecureStore from 'expo-secure-store';
+import * as Sentry from '@sentry/react-native';
 import LoggingService from './services/LoggingService';
 import APIService, { APIError } from './services/APIService';
 
@@ -76,7 +77,13 @@ export const AuthProvider = ({ children }) => {
         updateCachedAuthToken(storedToken);
       }
     } catch (error) {
+      // Unlike the background token read above, this runs in the foreground on
+      // mount — a failure here means a broken session on a real launch, not an
+      // expected background SecureStore denial.
       console.error('Error checking auth state:', error);
+      Sentry.captureException(error, {
+        tags: { section: 'auth_startup', error_type: 'auth_state_check' },
+      });
     } finally {
       setLoading(false);
     }

--- a/__tests__/AuthContext.test.js
+++ b/__tests__/AuthContext.test.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render, waitFor } from '@testing-library/react-native';
+import * as SecureStore from 'expo-secure-store';
+import * as Sentry from '@sentry/react-native';
+import { AuthProvider, useAuth } from '../AuthContext';
+
+// The startup auth check reads SecureStore and JSON.parses the stored user.
+// Both can fail on a corrupted install, and both were previously swallowed
+// into console.error — invisible in Sentry.
+function AuthProbe() {
+  const { loading } = useAuth();
+  return <Text>{loading ? 'loading' : 'ready'}</Text>;
+}
+
+const renderProvider = async () => {
+  const view = render(
+    <AuthProvider>
+      <AuthProbe />
+    </AuthProvider>
+  );
+  await waitFor(() => view.getByText('ready'));
+  return view;
+};
+
+describe('AuthProvider startup auth check', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reports a SecureStore read failure to Sentry', async () => {
+    const failure = new Error('keychain unavailable');
+    SecureStore.getItemAsync.mockRejectedValue(failure);
+
+    await renderProvider();
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      failure,
+      expect.objectContaining({
+        tags: expect.objectContaining({ section: 'auth_startup' }),
+      })
+    );
+  });
+
+  it('reports corrupted stored user JSON to Sentry', async () => {
+    SecureStore.getItemAsync.mockImplementation(async (key) =>
+      key === 'authToken' ? 'a-token' : '{not valid json'
+    );
+
+    await renderProvider();
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      expect.any(SyntaxError),
+      expect.objectContaining({
+        tags: expect.objectContaining({ section: 'auth_startup' }),
+      })
+    );
+  });
+
+  it('does not report to Sentry when there is no stored session', async () => {
+    SecureStore.getItemAsync.mockResolvedValue(null);
+
+    await renderProvider();
+
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/config/sentry.test.js
+++ b/__tests__/config/sentry.test.js
@@ -1,0 +1,98 @@
+const DSN = 'https://examplekey@o0.ingest.us.sentry.io/0';
+
+// babel-preset-expo rewrites `process.env.EXPO_PUBLIC_*` reads to the
+// `expo/virtual/env` module, which holds a live reference to process.env.
+// Mutate process.env in place — reassigning it would detach that reference.
+//
+// Sentry must be required *after* jest.resetModules(), so the test and
+// config/sentry.js share the same mock instance.
+describe('initSentry', () => {
+  const ENV_KEYS = ['EXPO_PUBLIC_SENTRY_DSN', 'EXPO_PUBLIC_BUILD_TYPE'];
+  const originalValues = {};
+
+  beforeAll(() => {
+    ENV_KEYS.forEach((key) => { originalValues[key] = process.env[key]; });
+  });
+
+  beforeEach(() => {
+    jest.resetModules();
+    ENV_KEYS.forEach((key) => { delete process.env[key]; });
+  });
+
+  afterAll(() => {
+    ENV_KEYS.forEach((key) => {
+      if (originalValues[key] === undefined) delete process.env[key];
+      else process.env[key] = originalValues[key];
+    });
+  });
+
+  const load = () => ({
+    Sentry: require('@sentry/react-native'),
+    initSentry: require('../../config/sentry').initSentry,
+  });
+
+  it('stays silent when no DSN is configured', () => {
+    const { Sentry, initSentry } = load();
+
+    initSentry();
+
+    expect(Sentry.init).not.toHaveBeenCalled();
+  });
+
+  it('initializes with the configured DSN', () => {
+    process.env.EXPO_PUBLIC_SENTRY_DSN = DSN;
+    const { Sentry, initSentry } = load();
+
+    initSentry();
+
+    expect(Sentry.init).toHaveBeenCalledTimes(1);
+    expect(Sentry.init.mock.calls[0][0].dsn).toBe(DSN);
+  });
+
+  it('enables native crash handling so launch-time native crashes are captured', () => {
+    process.env.EXPO_PUBLIC_SENTRY_DSN = DSN;
+    const { Sentry, initSentry } = load();
+
+    initSentry();
+
+    expect(Sentry.init.mock.calls[0][0].enableNativeCrashHandling).toBe(true);
+  });
+
+  it('tracks watchdog terminations so iOS launch hangs are reported', () => {
+    process.env.EXPO_PUBLIC_SENTRY_DSN = DSN;
+    const { Sentry, initSentry } = load();
+
+    initSentry();
+
+    expect(Sentry.init.mock.calls[0][0].enableWatchdogTerminationTracking).toBe(true);
+  });
+
+  it('tags events with the build type as the environment', () => {
+    process.env.EXPO_PUBLIC_SENTRY_DSN = DSN;
+    process.env.EXPO_PUBLIC_BUILD_TYPE = 'preview';
+    const { Sentry, initSentry } = load();
+
+    initSentry();
+
+    expect(Sentry.init.mock.calls[0][0].environment).toBe('preview');
+  });
+
+  it('falls back to an unknown environment when no build type is set', () => {
+    process.env.EXPO_PUBLIC_SENTRY_DSN = DSN;
+    const { Sentry, initSentry } = load();
+
+    initSentry();
+
+    expect(Sentry.init.mock.calls[0][0].environment).toBe('unknown');
+  });
+
+  it('initializes only once across repeated calls', () => {
+    process.env.EXPO_PUBLIC_SENTRY_DSN = DSN;
+    const { Sentry, initSentry } = load();
+
+    initSentry();
+    initSentry();
+
+    expect(Sentry.init).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/easConfig.test.js
+++ b/__tests__/easConfig.test.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+
+// The app shipped for months with crash reporting silently disabled because
+// EXPO_PUBLIC_SENTRY_DSN was never set in any build profile — initSentry()
+// returns early without a DSN. Guard the profiles that ship to real devices.
+const easConfig = JSON.parse(
+  fs.readFileSync(path.join(__dirname, '../eas.json'), 'utf8')
+);
+
+const REPORTING_PROFILES = ['debug', 'preview', 'production', 'production-simulator'];
+
+describe('eas.json build profiles', () => {
+  it.each(REPORTING_PROFILES)('profile "%s" defines a Sentry DSN', (profile) => {
+    const env = easConfig.build[profile].env;
+
+    expect(env.EXPO_PUBLIC_SENTRY_DSN).toMatch(/^https:\/\/.+@.+\/\d+$/);
+  });
+
+  it.each(REPORTING_PROFILES)('profile "%s" defines a build type to tag events with', (profile) => {
+    const env = easConfig.build[profile].env;
+
+    expect(env.EXPO_PUBLIC_BUILD_TYPE).toBe(profile);
+  });
+});

--- a/__tests__/services/TimelineDatabase.test.js
+++ b/__tests__/services/TimelineDatabase.test.js
@@ -1,0 +1,55 @@
+// The startup SQLite open is a prime suspect for launch-time crash loops
+// (corrupt db file → every launch throws). Sentry needs to see it happen and
+// see it fail, so a reinstall isn't the only diagnosis available.
+describe('TimelineDatabase startup instrumentation', () => {
+  let Sentry;
+  let SQLite;
+  let TimelineDatabase;
+  let mockDb;
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    mockDb = { execAsync: jest.fn().mockResolvedValue(undefined) };
+
+    jest.doMock('expo-sqlite', () => ({
+      openDatabaseAsync: jest.fn(async () => mockDb),
+    }));
+
+    Sentry = require('@sentry/react-native');
+    SQLite = require('expo-sqlite');
+    TimelineDatabase = require('../../services/TimelineDatabase').default;
+  });
+
+  it('leaves a breadcrumb when the timeline database opens', async () => {
+    await TimelineDatabase.init();
+
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'startup',
+        message: 'TimelineDatabase initialized',
+      })
+    );
+  });
+
+  it('reports the exception when the timeline database fails to open', async () => {
+    const failure = new Error('database disk image is malformed');
+    SQLite.openDatabaseAsync.mockRejectedValueOnce(failure);
+
+    await expect(TimelineDatabase.init()).rejects.toThrow(failure);
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      failure,
+      expect.objectContaining({
+        tags: expect.objectContaining({ section: 'timeline_database' }),
+      })
+    );
+  });
+
+  it('does not reopen an already-initialized database', async () => {
+    await TimelineDatabase.init();
+    await TimelineDatabase.init();
+
+    expect(SQLite.openDatabaseAsync).toHaveBeenCalledTimes(1);
+  });
+});

--- a/config/sentry.js
+++ b/config/sentry.js
@@ -10,6 +10,11 @@ export function initSentry() {
     dsn,
     enabled: !__DEV__,
     tracesSampleRate: 0.2,
+    environment: process.env.EXPO_PUBLIC_BUILD_TYPE || 'unknown',
+    // Launch-time crashes are the ones we can't see from JS: a native crash or
+    // an iOS watchdog termination kills the app before any JS handler runs.
+    enableNativeCrashHandling: true,
+    enableWatchdogTerminationTracking: true,
   });
   initialized = true;
 }

--- a/eas.json
+++ b/eas.json
@@ -27,6 +27,7 @@
       "distribution": "internal",
       "env": {
         "EXPO_PUBLIC_API_URL": "https://haps.app",
+        "EXPO_PUBLIC_SENTRY_DSN": "https://9c7c2e67c26186ebe88339d35c9f3a26@o4506169033621504.ingest.us.sentry.io/4507059749781504",
         "EXPO_PUBLIC_BUILD_TYPE": "debug",
         "EXPO_PUBLIC_DEBUG_MODE": "true"
       },
@@ -38,6 +39,7 @@
       "distribution": "internal",
       "env": {
         "EXPO_PUBLIC_API_URL": "https://haps.app",
+        "EXPO_PUBLIC_SENTRY_DSN": "https://9c7c2e67c26186ebe88339d35c9f3a26@o4506169033621504.ingest.us.sentry.io/4507059749781504",
         "EXPO_PUBLIC_BUILD_TYPE": "preview"
       }
     },
@@ -45,6 +47,7 @@
       "autoIncrement": true,
       "env": {
         "EXPO_PUBLIC_API_URL": "https://haps.app",
+        "EXPO_PUBLIC_SENTRY_DSN": "https://9c7c2e67c26186ebe88339d35c9f3a26@o4506169033621504.ingest.us.sentry.io/4507059749781504",
         "EXPO_PUBLIC_BUILD_TYPE": "production"
       },
       "ios": {
@@ -56,6 +59,7 @@
       "distribution": "internal",
       "env": {
         "EXPO_PUBLIC_API_URL": "https://haps.app",
+        "EXPO_PUBLIC_SENTRY_DSN": "https://9c7c2e67c26186ebe88339d35c9f3a26@o4506169033621504.ingest.us.sentry.io/4507059749781504",
         "EXPO_PUBLIC_BUILD_TYPE": "production-simulator"
       },
       "ios": {

--- a/services/TimelineDatabase.js
+++ b/services/TimelineDatabase.js
@@ -1,4 +1,5 @@
 import * as SQLite from 'expo-sqlite';
+import * as Sentry from '@sentry/react-native';
 import LoggingService from './LoggingService';
 
 class TimelineDatabase {
@@ -9,9 +10,24 @@ class TimelineDatabase {
   async init() {
     if (this.db) return this.db;
 
-    this.db = await SQLite.openDatabaseAsync('timeline.db');
-    await this.createTables();
-    return this.db;
+    try {
+      this.db = await SQLite.openDatabaseAsync('timeline.db');
+      await this.createTables();
+      Sentry.addBreadcrumb({
+        category: 'startup',
+        message: 'TimelineDatabase initialized',
+        level: 'info',
+      });
+      return this.db;
+    } catch (error) {
+      // A corrupt or unreadable db file throws on every launch, which looks
+      // like an unexplained crash loop unless we report it.
+      this.db = null;
+      Sentry.captureException(error, {
+        tags: { section: 'timeline_database', error_type: 'initialization_error' },
+      });
+      throw error;
+    }
   }
 
   async createTables() {


### PR DESCRIPTION
The app has never reported a crash to Sentry. `initSentry()` returns early when `EXPO_PUBLIC_SENTRY_DSN` is unset, and it was set nowhere — not in `eas.json`, not in `.env*`, and not in the EAS remote environment (which holds only `SENTRY_AUTH_TOKEN`, used for source-map upload at build time). The `haps/mobile` Sentry project has **zero events in 90 days** as a result, so this mornings crash loop left no trace.

## Changes

- **Wire the DSN.** Set `EXPO_PUBLIC_SENTRY_DSN` in every profile that ships to a real device (`debug`, `preview`, `production`, `production-simulator`), plus a test that fails if it ever goes missing again. Chose `eas.json` over an EAS remote env var because the release profiles have no `environment` key — adding one would also change how the existing `SENTRY_AUTH_TOKEN` secret resolves. A DSN is a public identifier that ships in the binary regardless.
- **Capture launch-time crashes.** `enableNativeCrashHandling` and `enableWatchdogTerminationTracking`. A native crash or an iOS watchdog kill at launch happens before any JS handler runs — precisely the crash-loop-until-reinstall case.
- **Tag the environment** from `EXPO_PUBLIC_BUILD_TYPE`, so TestFlight and internal builds are separable from production.
- **Instrument the two startup paths that can crash-loop a corrupted install:** the timeline SQLite open and the SecureStore auth check. Both previously failed into `console.error` only.

## Verification

- Full suite green: 15 suites, 103 passed (was 82).
- Confirmed end to end that a production babel transform inlines the DSN as a string literal into the bundle and resolves `environment` to `"production"` — the wiring that was actually broken.

Note: the reporting only takes effect in a **new build**. The currently installed build still has no DSN compiled in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012qfLsp1DviT1FRbrpogSCs