### PR TITLE
Fix build-101 launch crash: null AppState.currentState in permission flow

### DIFF
--- a/__tests__/contexts/AppStateContextNullState.test.js
+++ b/__tests__/contexts/AppStateContextNullState.test.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import { Text, AppState } from 'react-native';
+import { render, act } from '@testing-library/react-native';
+
+jest.mock('../../services', () => ({
+  LocationService: {
+    checkLocationPermission: jest.fn(() => Promise.resolve(true)),
+    isLocationTrackingActive: jest.fn(() => Promise.resolve(false)),
+  },
+  HeartbeatService: {
+    startHeartbeat: jest.fn(() => Promise.resolve()),
+  },
+}));
+
+jest.mock('../../services/LoggingService', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+  location: jest.fn(),
+}));
+
+jest.mock('expo-network', () => ({
+  getNetworkStateAsync: jest.fn(() =>
+    Promise.resolve({ isConnected: true, isInternetReachable: true, type: 'WIFI' })
+  ),
+  addNetworkStateListener: jest.fn(() => ({ remove: jest.fn() })),
+}));
+
+// Regression test for the build-101 launch crash (Sentry MOBILE-38):
+// AppState.currentState is documented to be null briefly at startup. When the
+// provider module captured that null into initialState and the first 'change'
+// event fired (a permission dialog does exactly this), the listener called
+// state.appState.match(...) — a TypeError thrown synchronously inside a native
+// event callback, which no error boundary can catch and which aborts the app
+// as a fatal jsi::JSError.
+describe('AppStateProvider with null AppState.currentState at startup', () => {
+  it('survives the first AppState change events without throwing', () => {
+    let changeHandler = null;
+
+    Object.defineProperty(AppState, 'currentState', {
+      configurable: true,
+      get: () => null,
+    });
+    jest.spyOn(AppState, 'addEventListener').mockImplementation((type, handler) => {
+      if (type === 'change') changeHandler = handler;
+      return { remove: jest.fn() };
+    });
+
+    // Require after currentState is null so module-level initialState captures it,
+    // matching the real startup race.
+    const { AppStateProvider } = require('../../contexts/AppStateContext');
+    render(
+      <AppStateProvider>
+        <Text>child</Text>
+      </AppStateProvider>
+    );
+
+    expect(typeof changeHandler).toBe('function');
+
+    // Permission dialog appears → 'inactive', then is dismissed → 'active'
+    expect(() => {
+      act(() => changeHandler('inactive'));
+      act(() => changeHandler('active'));
+    }).not.toThrow();
+  });
+
+  it('reports instead of dying when a listener dependency throws', () => {
+    let changeHandler = null;
+
+    jest.spyOn(AppState, 'addEventListener').mockImplementation((type, handler) => {
+      if (type === 'change') changeHandler = handler;
+      return { remove: jest.fn() };
+    });
+    const LoggingService = require('../../services/LoggingService');
+    LoggingService.info.mockImplementation(() => {
+      throw new Error('logging exploded');
+    });
+    const Sentry = require('@sentry/react-native');
+
+    const { AppStateProvider } = require('../../contexts/AppStateContext');
+    render(
+      <AppStateProvider>
+        <Text>child</Text>
+      </AppStateProvider>
+    );
+
+    expect(() => act(() => changeHandler('active'))).not.toThrow();
+    expect(Sentry.captureException).toHaveBeenCalled();
+  });
+});

--- a/contexts/AppStateContext.js
+++ b/contexts/AppStateContext.js
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useReducer, useEffect } from 'react';
 import { AppState } from 'react-native';
 import * as Network from 'expo-network';
+import * as Sentry from '@sentry/react-native';
 import { LocationService, HeartbeatService } from '../services';
 import LoggingService from '../services/LoggingService';
 
@@ -39,7 +40,10 @@ const appStateReducer = (state, action) => {
 };
 
 const initialState = {
-  appState: AppState.currentState,
+  // AppState.currentState can be null briefly at startup; a null here made the
+  // change listener's .match() throw inside a native event callback, killing
+  // the app as a fatal jsi::JSError (Sentry MOBILE-38).
+  appState: AppState.currentState || 'unknown',
   networkState: { isConnected: true, isInternetReachable: true, type: 'unknown' },
   locationPermission: null,
   isTrackingLocation: false,
@@ -58,24 +62,33 @@ export const AppStateProvider = ({ children }) => {
 
   // Handle app state changes
   useEffect(() => {
+    // A synchronous throw in this callback runs inside a native event dispatch:
+    // no error boundary applies and the app dies as a fatal jsi::JSError
+    // (Sentry MOBILE-38), so the whole body is guarded.
     const subscription = AppState.addEventListener('change', (nextAppState) => {
-      LoggingService.info('App state changed', {
-        event_type: 'app_state',
-        action: 'state_change',
-        previous_state: state.appState,
-        new_state: nextAppState,
-      });
-      
-      dispatch({ type: 'SET_APP_STATE', payload: nextAppState });
-      
-      // Handle app becoming active
-      if (state.appState.match(/inactive|background/) && nextAppState === 'active') {
-        handleAppBecameActive();
-      }
-      
-      // Handle app going to background
-      if (nextAppState.match(/inactive|background/)) {
-        handleAppWentToBackground();
+      try {
+        LoggingService.info('App state changed', {
+          event_type: 'app_state',
+          action: 'state_change',
+          previous_state: state.appState,
+          new_state: nextAppState,
+        });
+
+        dispatch({ type: 'SET_APP_STATE', payload: nextAppState });
+
+        // Handle app becoming active
+        if (state.appState.match(/inactive|background/) && nextAppState === 'active') {
+          handleAppBecameActive();
+        }
+
+        // Handle app going to background
+        if (nextAppState.match(/inactive|background/)) {
+          handleAppWentToBackground();
+        }
+      } catch (error) {
+        Sentry.captureException(error, {
+          tags: { section: 'app_state', error_type: 'app_state_change_error' },
+        });
       }
     });
 


### PR DESCRIPTION
## Root-cause fix for the build-101 launch crashes (Sentry MOBILE-38)

`AppState.currentState` can be `null` briefly at startup. Module-level `initialState` in `AppStateContext` captured that null, and the first AppState change event — exactly what a location permission dialog triggers — hit `state.appState.match(...)`: a TypeError thrown synchronously inside a native event callback. No error boundary applies there, and on the new architecture the throw aborts the app as a fatal `jsi::JSError` before the JS Sentry event can flush. All 4 build-101 crashes match this signature (in the permission flow, near launch, no JS event).

**Fix** (one commit off current main):
- default initial `appState` to `'unknown'`
- guard the change-listener body with a try/catch + Sentry capture, so any future throw in this native-callback context reports instead of killing the app

**Repro test**: `AppStateContextNullState.test.js` fails on unfixed main with the exact production TypeError (verified by stashing the fix); passes with it. Full suite: 16 suites, 105 passed.

Note: the launch auto-start-tracking cherry-pick that was previously in this PR has been dropped to avoid conflicting with the `redesign/phase-3-timeline-editing` lineage — auto-start should land via that branch's reconciliation instead.

Fixes MOBILE-38

🤖 Generated with [Claude Code](https://claude.com/claude-code)